### PR TITLE
Add stacktrace as slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ format: ## Format source files
 	@go mod tidy -e
 	@docker run --rm -t -v $(shell pwd):/app -v ~/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION):/root/.cache -w /app \
 		golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) \
-		golangci-lint --fix \
+		golangci-lint run --fix \
 		--deadline=65s \
 		./...
 

--- a/errors.go
+++ b/errors.go
@@ -131,6 +131,18 @@ func (e *Error) StackTraceString(verbosity int) string {
 	return buf.String()
 }
 
+func StackTraceSlice(err error) []string {
+	var stack []string
+	stacked, ok := err.(*Error)
+	if !ok {
+		return stack
+	}
+	for _, d := range stacked.StackTrace() {
+		stack = append(stack, fmt.Sprintf("%s:%d", d.RelFileName(), d.FileLine()))
+	}
+	return stack
+}
+
 // Creates a new error with a stack trace.
 // Supports interpolating of message parameters.
 //

--- a/test/format_test.go
+++ b/test/format_test.go
@@ -76,6 +76,18 @@ func (suite *FormatSuite) TestFormats() {
 	}
 }
 
+func (suite *FormatSuite) TestStackTraceSlice() {
+	err := foo()
+	got := errors.StackTraceSlice(err)
+	suite.Assert().Len(got, 7, "StackTraceSlice has no expected len")
+}
+
+func (suite *FormatSuite) TestStackTraceSliceNoError() {
+	err := fmt.Errorf("some err")
+	got := errors.StackTraceSlice(err)
+	suite.Assert().Len(got, 0, "StackTraceSlice has no expected len")
+}
+
 func foo() error {
 	err := bar()
 	return errors.Wrap(err, "foo failed")


### PR DESCRIPTION
## Changes

I add a way to show stacktrace as slice. This can be useful when you need to log. (I was not able to log this data in a file without given format, so I thought this would be useful)

## Checklist
- [X] I have checked that there is no similar [pull request](https://github.com/coditory/go-errors/pulls) already submitted
- [X] I have read [contributing.md](https://github.com/coditory/go-errors/blob/main/.github/CONTRIBUTING.md) and applied to the rules
- [X] I have unit tested code changes and performed a self-review
